### PR TITLE
Update follow API behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,5 @@ dmypy.json
 .pyre/
 
 
-# db population files
 media/
 static/

--- a/api/profiles/serializers.py
+++ b/api/profiles/serializers.py
@@ -1,4 +1,5 @@
 """Serializers for the Profiles app."""
+from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 
 from .models import Follow, Profile
@@ -74,6 +75,7 @@ class CreateFollowSerializer(serializers.ModelSerializer):
 
     def validate_following_id(self, value):
         """Ensure `value` is a valid following ID for the current user's profile."""
+        get_object_or_404(Profile, id=value)
         current_profile = self.context.get("current_profile")
         follow_exists = Follow.objects.filter(
             follower=current_profile, following_id=value

--- a/api/profiles/tests/test_follow_api.py
+++ b/api/profiles/tests/test_follow_api.py
@@ -110,6 +110,19 @@ class TestCreateFollow:
         assert response.data == {"following_id": ["You cannot follow yourself."]}
         assert Follow.objects.count() == 0
 
+    def test_follow_non_existing_profile_returns_404(
+        self, api_client, sample_user, sample_profile, follow_payload
+    ):
+        """Test follow non existing profile returns error."""
+        api_client.force_authenticate(user=sample_user)
+        follow_payload.update({"following_id": sample_profile.id + 2})
+
+        response = api_client.post(FOLLOW_URL, follow_payload)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.data == {"detail": "Not found."}
+        assert Follow.objects.count() == 0
+
     def test_anonymous_user_follow_returns_401(self, api_client, follow_payload):
         """Test anonymous users cannot follow others."""
 

--- a/api/profiles/views.py
+++ b/api/profiles/views.py
@@ -120,9 +120,13 @@ class FollowViewSet(CreateModelMixin, DestroyModelMixin, GenericViewSet):
             self._current_profile = Profile.objects.get(user=self.request.user)
         return self._current_profile
 
-    def get_queryset(self):
-        """Filter queryset to only follows that the current profile is the follower."""
-        return self.queryset.filter(follower=self.get_current_profile())
+    def get_object(self):
+        """Return the follow object for the current user and requested profile."""
+        following_id = self.kwargs.get("pk")
+        follow = get_object_or_404(
+            Follow, follower=self.get_current_profile(), following_id=following_id
+        )
+        return follow
 
     def get_serializer_context(self):
         """Pass the current user's profile to the serializer."""


### PR DESCRIPTION
### Changes
1. When following a profile, ensure a 404 error is returned when the profile specified does not exist.
2. To unfollow a profile, the profile **id** is now put in the URL like so: `/profile/follows/id/`. Previously, the id in this URL was the id of the follow object to be deleted; however, this didn't make sense because the follow id wouldn't be easily accessible to be used in the request.